### PR TITLE
Ignore errors from disposing plots

### DIFF
--- a/src/FnuPlot/FnuPlot.fs
+++ b/src/FnuPlot/FnuPlot.fs
@@ -374,7 +374,7 @@ type GnuPlot private (actualPath:string) =
   new(?path:string) = new GnuPlot(actualPath=defaultArg path "gnuplot")
 
   // We want to dipose of the running process when the wrapper is disposed
-  // The followign bits implement proper 'disposal' pattern
+  // The following bits implement proper 'disposal' pattern
   member private x.Dispose(disposing) = 
    gp.Kill()  
    if disposing then gp.Dispose()

--- a/src/FnuPlot/FnuPlot.fs
+++ b/src/FnuPlot/FnuPlot.fs
@@ -375,13 +375,19 @@ type GnuPlot private (actualPath:string) =
 
   // We want to dipose of the running process when the wrapper is disposed
   // The following bits implement proper 'disposal' pattern
-  member private x.Dispose(disposing) = 
-   gp.Kill()  
-   if disposing then gp.Dispose()
+  member private x.Dispose(disposing) =
+    try
+      gp.Kill()  
+      if disposing then gp.Dispose()
+    with
+      _->()
 
   /// [omit]
-  override x.Finalize() = 
-    x.Dispose(false)
+  override x.Finalize() =
+    try
+      x.Dispose(false)
+    with
+      _->()
     
   interface System.IDisposable with
     member x.Dispose() = 


### PR DESCRIPTION
When using FnuPlot (and the old gnuplot.fs) with mono and fsi I would always get nullreference errors. After some diggin around I discovered that the errors are generated from unnecessary calling of the Dispose and Finalize methods. I lieu of fixing this i simply ignore those errors. This allows for smooth use of the library without interrupting errors on Mono.