### PR TITLE
Added output type Qt as alternative to X11 option.

### DIFF
--- a/src/FnuPlot/FnuPlot.fs
+++ b/src/FnuPlot/FnuPlot.fs
@@ -256,6 +256,8 @@ type Style(?fill) =
 type OutputType = 
   /// Creates charts in a new window
   | X11
+  /// Creates charts in a new Qt window on OS X
+  | Qt
   /// Saves charts to a specified PNG file
   | Png of string
   /// Saves charts to a specified EPS file
@@ -273,6 +275,7 @@ type Output(output:OutputType, ?font) =
       let font = font |> formatArg (sprintf " font '%s'")
       match output with 
       | X11 -> "set term x11" + font
+      | Qt -> "set terminal qt" + font
       | Png(s) -> sprintf "set term png%s\nset output '%s'" font s
       | Eps(s) -> sprintf "set term postscript eps enhanced%s\nset output '%s'" font s
     member x.Cleanup = "set term x11"


### PR DESCRIPTION
In OS X Yosemite 10.10.2 and El Capitan 10.11.2, gnuplot does not package with XQuartz. A window manager that has proved more robust on these systems is qt.